### PR TITLE
Adds server/Options.IdFunc config to generate a node identifier from RPC server listener details

### DIFF
--- a/options.go
+++ b/options.go
@@ -13,9 +13,11 @@ import (
 )
 
 type Options struct {
-	Name      string
-	Version   string
-	Id        string
+	Name    string
+	Version string
+	Id      string
+	// IdFunc is an Id generator function called prior to registration of the service, replacing the Id option value.
+	IdFunc    func(addr string, port int) string
 	Metadata  map[string]string
 	Address   string
 	Advertise string

--- a/service.go
+++ b/service.go
@@ -75,6 +75,10 @@ func (s *service) genSrv() *registry.Service {
 		addr = "127.0.0.1"
 	}
 
+	if s.opts.IdFunc != nil {
+		s.opts.Id = s.opts.IdFunc(addr, port)
+	}
+
 	return &registry.Service{
 		Name:    s.opts.Name,
 		Version: s.opts.Version,


### PR DESCRIPTION
In a similar vein to https://github.com/divisionone/go-micro/pull/22, we need to ability to generate a service node identifier based on the RPC listener details: address + port the server was bound to during startup.

`go-web` doesn't protect it's options field with a mutex like `go-micro`, so this implementation has fewer moving parts than its counterpart.